### PR TITLE
Fix an issue with the display order of options and commands in Help

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceFolder}/example/JSSoft.Commands.Invoke/bin/Debug/net8.0/invoke.dll",
-            "args": "list --help",
+            "args": "--help",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/example/JSSoft.Commands.Invoke/bin/Debug/net8.0",
             "stopAtEntry": false,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ To be Released.
 * Simplified the process of getting strings from `ResourceManager`.  [[#34]]
 * Removed `ICommandUsage`, `CommandUsageDescriptorBase`, 
   `ResourceUsageDescriptor`.  [[#34]]
+* Fixed an issue with the display order of options and commands in Help.  
+  [[#37]]
 
 
 [#13]: https://github.com/s2quake/commands/pull/13
@@ -39,6 +41,7 @@ To be Released.
 [#31]: https://github.com/s2quake/commands/pull/31
 [#33]: https://github.com/s2quake/commands/pull/33
 [#34]: https://github.com/s2quake/commands/pull/34
+[#37]: https://github.com/s2quake/commands/pull/37
 
 
 6.0.1

--- a/src/JSSoft.Commands/CommandCollection.cs
+++ b/src/JSSoft.Commands/CommandCollection.cs
@@ -92,6 +92,22 @@ public sealed class CommandCollection : IEnumerable<ICommand>
     public bool TryGetValue(string name, [MaybeNullWhen(false)] out ICommand value)
         => _commandByName.TryGetValue(name, out value);
 
+    public IGrouping<string, ICommand>[] GroupByCategory()
+        => GroupByCategory(_ => true);
+
+    public IGrouping<string, ICommand>[] GroupByCategory(Predicate<string> categoryPredicate)
+    {
+        var query = from child in this
+                    where child.IsEnabled is true
+                    let category = child.Category
+                    where categoryPredicate(category) is true
+                    orderby category != string.Empty
+                    orderby category
+                    group child by category into @group
+                    select @group;
+        return query.ToArray();
+    }
+
     public IEnumerator<ICommand> GetEnumerator() => _commandList.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => _commandList.GetEnumerator();

--- a/src/JSSoft.Commands/CommandCollection.cs
+++ b/src/JSSoft.Commands/CommandCollection.cs
@@ -102,7 +102,6 @@ public sealed class CommandCollection : IEnumerable<ICommand>
                     let category = child.Category
                     where categoryPredicate(category) is true
                     orderby category != string.Empty
-                    orderby category
                     group child by category into @group
                     select @group;
         return query.ToArray();

--- a/src/JSSoft.Commands/CommandInvocationException.cs
+++ b/src/JSSoft.Commands/CommandInvocationException.cs
@@ -111,7 +111,7 @@ public class CommandInvocationException(
         };
         if (invocationHelp.Command == string.Empty)
         {
-            usagePrinter.Print(writer, [.. methodDescriptors]);
+            usagePrinter.Print(writer, methodDescriptors);
         }
         else if (methodDescriptors.FindByName(invocationHelp.Command) is { } methodDescriptor)
         {

--- a/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
@@ -116,7 +116,6 @@ public class CommandInvocationUsagePrinter(
     {
         var query = from methodDescriptor in methodDescriptors
                     where categoryPredicate(methodDescriptor.Category) is true
-                    orderby methodDescriptor.Name
                     orderby methodDescriptor.Category
                     group methodDescriptor by methodDescriptor.Category into @group
                     select @group;
@@ -148,7 +147,6 @@ public class CommandInvocationUsagePrinter(
         CommandTextWriter commandWriter, CommandMethodDescriptor[] methodDescriptors)
     {
         var query = from methodDescriptor in methodDescriptors
-                    orderby methodDescriptor.Name
                     orderby methodDescriptor.Category
                     group methodDescriptor by methodDescriptor.Category into @group
                     select @group;

--- a/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
@@ -13,7 +13,8 @@ public class CommandInvocationUsagePrinter(
     string executionName, CommandUsage commandUsage, CommandSettings settings)
     : CommandUsagePrinterBase(settings)
 {
-    public virtual void Print(TextWriter writer, CommandMethodDescriptor[] methodDescriptors)
+    public virtual void Print(
+        TextWriter writer, CommandMethodDescriptorCollection methodDescriptors)
     {
         using var commandWriter = new CommandTextWriter(writer, Settings);
         if (IsDetail is true)
@@ -111,16 +112,11 @@ public class CommandInvocationUsagePrinter(
 
     protected static void PrintCommands(
         CommandTextWriter commandWriter,
-        CommandMethodDescriptor[] methodDescriptors,
+        CommandMethodDescriptorCollection methodDescriptors,
         Predicate<string> categoryPredicate)
     {
-        var query = from methodDescriptor in methodDescriptors
-                    where categoryPredicate(methodDescriptor.Category) is true
-                    orderby methodDescriptor.Category
-                    group methodDescriptor by methodDescriptor.Category into @group
-                    select @group;
-
-        foreach (var @group in query)
+        var groups = methodDescriptors.GroupByCategory(categoryPredicate);
+        foreach (var @group in groups)
         {
             var itemList = new List<string>
             {
@@ -144,14 +140,10 @@ public class CommandInvocationUsagePrinter(
     }
 
     protected static void PrintCommandsInDetail(
-        CommandTextWriter commandWriter, CommandMethodDescriptor[] methodDescriptors)
+        CommandTextWriter commandWriter, CommandMethodDescriptorCollection methodDescriptors)
     {
-        var query = from methodDescriptor in methodDescriptors
-                    orderby methodDescriptor.Category
-                    group methodDescriptor by methodDescriptor.Category into @group
-                    select @group;
-
-        foreach (var @group in query)
+        var groups = methodDescriptors.GroupByCategory();
+        foreach (var @group in groups)
         {
             var itemList = new List<string>
             {

--- a/src/JSSoft.Commands/CommandMemberDescriptorCollection.cs
+++ b/src/JSSoft.Commands/CommandMemberDescriptorCollection.cs
@@ -28,8 +28,10 @@ public sealed class CommandMemberDescriptorCollection : IEnumerable<CommandMembe
 
         var query = from memberDescriptor in memberDescriptors
                     orderby memberDescriptor.DefaultValue != DBNull.Value
-                    orderby memberDescriptor.IsGeneral descending
+                    orderby memberDescriptor.IsGeneral || memberDescriptor.IsSwitch descending
                     orderby memberDescriptor.IsVariables descending
+                    orderby memberDescriptor.IsRequired
+                        && memberDescriptor.DefaultValue is not DBNull
                     orderby memberDescriptor.IsRequired && memberDescriptor.IsExplicit descending
                     orderby memberDescriptor.IsRequired descending
                     select memberDescriptor;

--- a/src/JSSoft.Commands/CommandMemberDescriptorCollection.cs
+++ b/src/JSSoft.Commands/CommandMemberDescriptorCollection.cs
@@ -27,7 +27,6 @@ public sealed class CommandMemberDescriptorCollection : IEnumerable<CommandMembe
         }
 
         var query = from memberDescriptor in memberDescriptors
-                    orderby memberDescriptor.DefaultValue != DBNull.Value
                     orderby memberDescriptor.IsGeneral || memberDescriptor.IsSwitch descending
                     orderby memberDescriptor.IsVariables descending
                     orderby memberDescriptor.IsRequired
@@ -145,6 +144,20 @@ public sealed class CommandMemberDescriptorCollection : IEnumerable<CommandMembe
     }
 
     public bool Contains(string memberName) => _itemByMemberName.Contains(memberName);
+
+    public IGrouping<string, CommandMemberDescriptor>[] GroupOptionsByCategory()
+        => GroupOptionsByCategory(_ => true);
+
+    public IGrouping<string, CommandMemberDescriptor>[] GroupOptionsByCategory(
+        Predicate<string> categoryPredicate)
+    {
+        var query = from item in OptionDescriptors
+                    where categoryPredicate(item.Category)
+                    orderby item.Category != string.Empty
+                    group item by item.Category into @group
+                    select @group;
+        return query.ToArray();
+    }
 
     IEnumerator<CommandMemberDescriptor> IEnumerable<CommandMemberDescriptor>.GetEnumerator()
     {

--- a/src/JSSoft.Commands/CommandMethodDescriptorCollection.cs
+++ b/src/JSSoft.Commands/CommandMethodDescriptorCollection.cs
@@ -95,6 +95,20 @@ public sealed class CommandMethodDescriptorCollection : IEnumerable<CommandMetho
         return false;
     }
 
+    public IGrouping<string, CommandMethodDescriptor>[] GroupByCategory()
+        => GroupByCategory(_ => true);
+
+    public IGrouping<string, CommandMethodDescriptor>[] GroupByCategory(
+        Predicate<string> categoryPredicate)
+    {
+        var query = from item in this
+                    where categoryPredicate(item.Category)
+                    orderby item.Category != string.Empty
+                    group item by item.Category into @group
+                    select @group;
+        return query.ToArray();
+    }
+
     IEnumerator<CommandMethodDescriptor> IEnumerable<CommandMethodDescriptor>.GetEnumerator()
     {
         foreach (var item in _methodDescriptorByMethodName.Values)

--- a/src/JSSoft.Commands/CommandUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinter.cs
@@ -70,16 +70,11 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
 
     protected static void PrintCommands(
         CommandTextWriter commandWriter,
-        IEnumerable<ICommand> commands,
+        CommandCollection commands,
         Predicate<string> categoryPredicate)
     {
-        var query = from command in commands
-                    where categoryPredicate(command.Category) is true
-                    orderby command.Category
-                    group command by command.Category into @group
-                    select @group;
-
-        foreach (var @group in query)
+        var groups = commands.GroupByCategory(categoryPredicate);
+        foreach (var @group in groups)
         {
             var itemList = new List<string>
             {

--- a/src/JSSoft.Commands/CommandUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinter.cs
@@ -75,7 +75,6 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
     {
         var query = from command in commands
                     where categoryPredicate(command.Category) is true
-                    orderby command.Name
                     orderby command.Category
                     group command by command.Category into @group
                     select @group;

--- a/src/JSSoft.Commands/CommandUsagePrinterBase.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinterBase.cs
@@ -197,7 +197,6 @@ public abstract class CommandUsagePrinterBase(CommandSettings settings)
         {
             var query = from memberDescriptor in memberDescriptors.OptionDescriptors
                         where categoryPredicate(memberDescriptor.Category) is true
-                        orderby memberDescriptor.Name
                         orderby memberDescriptor.Category
                         group memberDescriptor by memberDescriptor.Category into @group
                         select @group;
@@ -226,7 +225,6 @@ public abstract class CommandUsagePrinterBase(CommandSettings settings)
         if (memberDescriptors.HasOptions is true)
         {
             var query = from memberDescriptor in memberDescriptors.OptionDescriptors
-                        orderby memberDescriptor.Name
                         orderby memberDescriptor.Category
                         group memberDescriptor by memberDescriptor.Category into @group
                         select @group;

--- a/src/JSSoft.Commands/CommandUsagePrinterBase.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinterBase.cs
@@ -195,13 +195,8 @@ public abstract class CommandUsagePrinterBase(CommandSettings settings)
     {
         if (memberDescriptors.HasOptions is true)
         {
-            var query = from memberDescriptor in memberDescriptors.OptionDescriptors
-                        where categoryPredicate(memberDescriptor.Category) is true
-                        orderby memberDescriptor.Category
-                        group memberDescriptor by memberDescriptor.Category into @group
-                        select @group;
-
-            foreach (var @group in query)
+            var groups = memberDescriptors.GroupOptionsByCategory(categoryPredicate);
+            foreach (var @group in groups)
             {
                 var itemList = new List<string>
                 {
@@ -224,12 +219,8 @@ public abstract class CommandUsagePrinterBase(CommandSettings settings)
     {
         if (memberDescriptors.HasOptions is true)
         {
-            var query = from memberDescriptor in memberDescriptors.OptionDescriptors
-                        orderby memberDescriptor.Category
-                        group memberDescriptor by memberDescriptor.Category into @group
-                        select @group;
-
-            foreach (var @group in query)
+            var groups = memberDescriptors.GroupOptionsByCategory();
+            foreach (var @group in groups)
             {
                 var itemList = new List<string>
                 {

--- a/src/JSSoft.Commands/HelpCommandBase.cs
+++ b/src/JSSoft.Commands/HelpCommandBase.cs
@@ -83,15 +83,8 @@ public abstract class HelpCommandBase : CommandBase
         Predicate<string> categoryPredicate)
     {
         var rootNode = commandContext.Node;
-        var query = from child in rootNode.Commands
-                    where child.IsEnabled is true
-                    let category = child.Category
-                    where categoryPredicate(category) is true
-                    orderby category
-                    group child by category into @group
-                    select @group;
-
-        foreach (var @group in query)
+        var groups = rootNode.Commands.GroupByCategory(categoryPredicate);
+        foreach (var @group in groups)
         {
             var itemList = new List<string>
             {

--- a/src/JSSoft.Commands/HelpCommandBase.cs
+++ b/src/JSSoft.Commands/HelpCommandBase.cs
@@ -87,7 +87,6 @@ public abstract class HelpCommandBase : CommandBase
                     where child.IsEnabled is true
                     let category = child.Category
                     where categoryPredicate(category) is true
-                    orderby child.Name
                     orderby category
                     group child by category into @group
                     select @group;

--- a/test/JSSoft.Commands.Tests/CommandCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandCollectionTest.cs
@@ -1,0 +1,143 @@
+// <copyright file="CommandCollectionTest.cs" company="JSSoft">
+//   Copyright (c) 2024 Jeesu Choi. All Rights Reserved.
+//   Licensed under the MIT License. See LICENSE.md in the project root for license information.
+// </copyright>
+
+using System.ComponentModel;
+
+namespace JSSoft.Commands.Tests;
+
+public class CommandCollectionTest
+{
+    [Category("Hidden")]
+    private sealed class HiddenCommand : CommandBase
+    {
+        protected override void OnExecute()
+        {
+            // do something
+        }
+    }
+
+    [Category("Normal")]
+    private sealed class AddCommand : CommandBase
+    {
+        protected override void OnExecute()
+        {
+            // do something
+        }
+    }
+
+    [Category("Asset")]
+    private sealed class InitCommand : CommandBase
+    {
+        protected override void OnExecute()
+        {
+            // do something
+        }
+    }
+
+    private sealed class DeleteCommand : CommandBase
+    {
+        protected override void OnExecute()
+        {
+            // do something
+        }
+    }
+
+    [Fact]
+    public void Commands_Order_Test()
+    {
+        var items = new ICommand[]
+        {
+            new HiddenCommand(),
+            new AddCommand(),
+            new InitCommand(),
+            new DeleteCommand(),
+        };
+        var commands = new CommandCollection(items);
+        var index = 0;
+        Assert.Equal(4, commands.Count);
+        Assert.IsType<HiddenCommand>(commands[index++]);
+        Assert.IsType<AddCommand>(commands[index++]);
+        Assert.IsType<InitCommand>(commands[index++]);
+        Assert.IsType<DeleteCommand>(commands[index++]);
+        Assert.Equal(4, index);
+    }
+
+    [Fact]
+    public void Commands_GroupByCategory_Test()
+    {
+        var items = new ICommand[]
+        {
+            new HiddenCommand(),
+            new AddCommand(),
+            new InitCommand(),
+            new DeleteCommand(),
+        };
+        var commands = new CommandCollection(items);
+        var groups = commands.GroupByCategory();
+
+        Assert.Equal(4, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(DeleteCommand),
+            ]);
+        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(HiddenCommand),
+            ]);
+        Assert.Equal("Normal", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(AddCommand),
+            ]);
+        Assert.Equal("Asset", groups[3].Key);
+        Assert.Equal(
+            groups[3].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(InitCommand),
+            ]);
+    }
+
+    [Fact]
+    public void Commands_GroupByCategory_WithoutHidden_Test()
+    {
+        var settings = new CommandSettings();
+        var items = new ICommand[]
+        {
+            new HiddenCommand(),
+            new AddCommand(),
+            new InitCommand(),
+            new DeleteCommand(),
+        };
+        var commands = new CommandCollection(items);
+        var groups = commands.GroupByCategory(settings.CategoryPredicate);
+
+        Assert.Equal(3, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(DeleteCommand),
+            ]);
+        Assert.Equal("Normal", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(AddCommand),
+            ]);
+        Assert.Equal("Asset", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.GetType()).ToArray(),
+            [
+                typeof(InitCommand),
+            ]);
+    }
+}

--- a/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_Test.cs
@@ -41,8 +41,8 @@ public sealed class BasicClass_Test
         Assert.Equal(4, memberDescriptors.Count);
         Assert.Equal(nameof(BasicClass.Int), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Arguments), memberDescriptors[index++].MemberName);
-        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Bool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
 
         Assert.Equal(4, index);
     }
@@ -56,8 +56,8 @@ public sealed class BasicClass_Test
         Assert.Equal(4, memberDescriptors.Count);
         Assert.Equal(nameof(BasicClass.Int), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Arguments), memberDescriptors[index++].MemberName);
-        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Bool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
 
         Assert.Equal(4, index);
     }

--- a/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_With_1_StaticClass_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_With_1_StaticClass_Test.cs
@@ -56,15 +56,16 @@ public sealed class BasicClass_With_1_StaticClass_Test
     public void GetMemberDescriptors_Arg0_BasicClassType_Test()
     {
         var memberDescriptors = GetMemberDescriptors(typeof(BasicClass));
-
+        var index = 0;
         Assert.Equal(7, memberDescriptors.Count);
-        Assert.Equal(nameof(BasicClass.Int), memberDescriptors[0].MemberName);
-        Assert.Equal(nameof(StaticClass.StaticInt), memberDescriptors[1].MemberName);
-        Assert.Equal(nameof(BasicClass.Arguments), memberDescriptors[2].MemberName);
-        Assert.Equal(nameof(BasicClass.String), memberDescriptors[3].MemberName);
-        Assert.Equal(nameof(StaticClass.StaticString), memberDescriptors[4].MemberName);
-        Assert.Equal(nameof(BasicClass.Bool), memberDescriptors[5].MemberName);
-        Assert.Equal(nameof(StaticClass.StaticBool), memberDescriptors[6].MemberName);
+        Assert.Equal(nameof(BasicClass.Int), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(StaticClass.StaticInt), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.Arguments), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.Bool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(StaticClass.StaticBool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(StaticClass.StaticString), memberDescriptors[index++].MemberName);
+        Assert.Equal(7, index);
     }
 
     [CommandStaticProperty(typeof(StaticClass), nameof(StaticClass.StaticInt))]

--- a/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_With_2_StaticClass1_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/BasicClass_With_2_StaticClass1_Test.cs
@@ -63,8 +63,8 @@ public sealed class BasicClass_With_2_StaticClass1_Test
         Assert.Equal(nameof(StaticClass1.StaticInt1), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(StaticClass2.StaticInt2), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Arguments), memberDescriptors[index++].MemberName);
-        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(BasicClass.Bool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(BasicClass.String), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(StaticClass1.StaticBool1), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(StaticClass2.StaticBool2), memberDescriptors[index++].MemberName);
 

--- a/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/StaticClass_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandDescriptorTests/GetMemberDescriptorsTypeTests/StaticClass_Test.cs
@@ -40,8 +40,8 @@ public sealed class StaticClass_Test
         Assert.Equal(4, memberDescriptors.Count);
         Assert.Equal(nameof(StaticClass.Int), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(StaticClass.Arguments), memberDescriptors[index++].MemberName);
-        Assert.Equal(nameof(StaticClass.String), memberDescriptors[index++].MemberName);
         Assert.Equal(nameof(StaticClass.Bool), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(StaticClass.String), memberDescriptors[index++].MemberName);
 
         Assert.Equal(4, index);
     }

--- a/test/JSSoft.Commands.Tests/CommandMemberDescriptorCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandMemberDescriptorCollectionTest.cs
@@ -3,26 +3,144 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
+using System.ComponentModel;
+
 namespace JSSoft.Commands.Tests;
 
 public class CommandMemberDescriptorCollectionTest
 {
-    private sealed class StyleCommand
+    internal static class GlobalSettings
     {
-        [CommandPropertySwitch('i')]
-        [CommandPropertyDependency(nameof(StyleName))]
-        public bool IsDetail { get; set; }
+        [CommandProperty]
+        [Category("Asset")]
+        public static string Id { get; set; } = string.Empty;
 
-        [CommandPropertyRequired(DefaultValue = "")]
-        public string StyleName { get; set; } = string.Empty;
+        [CommandProperty]
+        public static string Password { get; set; } = string.Empty;
+
+        [CommandPropertyRequired]
+        public static string LogPath { get; set; } = string.Empty;
+
+        [CommandPropertyExplicitRequired]
+        public static string Platform { get; set; } = string.Empty;
+    }
+
+    [CommandStaticProperty(typeof(GlobalSettings))]
+    private sealed class Settings
+    {
+        [CommandPropertyRequired]
+        public string Path { get; set; } = string.Empty;
+
+        [CommandPropertyRequired]
+        public string ServiceName { get; set; } = string.Empty;
+
+        [CommandPropertyExplicitRequired]
+        public string WorkingPath { get; set; } = string.Empty;
+
+        [CommandProperty('p', useName: true, InitValue = "10001")]
+        [Category("Hidden")]
+        public int Port { get; set; }
+
+        [CommandPropertySwitch]
+        [Category("Normal")]
+        public bool UseCache { get; set; }
+
+        [CommandProperty("cache-size", DefaultValue = 1024)]
+        public int CacheSize { get; set; }
+
+        [CommandPropertyArray]
+        public string[] Libraries { get; set; } = [];
+
+        [CommandProperty]
+        [Category("Normal")]
+        public string Comment { get; set; } = string.Empty;
     }
 
     [Fact]
-    public void StyleCommand_PropertyOrder_Test()
+    public void Members_Order_Test()
     {
-        var memberDescriptors = CommandDescriptor.GetMemberDescriptors(typeof(StyleCommand));
-        Assert.Equal(2, memberDescriptors.Count);
-        Assert.Equal(nameof(StyleCommand.StyleName), memberDescriptors[0].MemberName);
-        Assert.Equal(nameof(StyleCommand.IsDetail), memberDescriptors[1].MemberName);
+        var memberDescriptors = CommandDescriptor.GetMemberDescriptors(typeof(Settings));
+        var index = 0;
+        Assert.Equal(12, memberDescriptors.Count);
+        Assert.Equal(nameof(Settings.WorkingPath), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(GlobalSettings.Platform), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.Path), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.ServiceName), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(GlobalSettings.LogPath), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.Libraries), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.Port), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.UseCache), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.CacheSize), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(Settings.Comment), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(GlobalSettings.Id), memberDescriptors[index++].MemberName);
+        Assert.Equal(nameof(GlobalSettings.Password), memberDescriptors[index++].MemberName);
+        Assert.Equal(12, index);
+    }
+
+    [Fact]
+    public void Members_GroupByCategory_Test()
+    {
+        var memberDescriptors = CommandDescriptor.GetMemberDescriptors(typeof(Settings));
+        var groups = memberDescriptors.GroupOptionsByCategory();
+
+        Assert.Equal(4, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(Settings.CacheSize),
+                nameof(GlobalSettings.Password),
+            ]);
+        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(Settings.Port),
+            ]);
+        Assert.Equal("Normal", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(Settings.UseCache),
+                nameof(Settings.Comment),
+            ]);
+        Assert.Equal("Asset", groups[3].Key);
+        Assert.Equal(
+            groups[3].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(GlobalSettings.Id),
+            ]);
+    }
+
+    [Fact]
+    public void Members_GroupByCategory_WithoutHidden_Test()
+    {
+        var settings = new CommandSettings();
+        var memberDescriptors = CommandDescriptor.GetMemberDescriptors(typeof(Settings));
+        var groups = memberDescriptors.GroupOptionsByCategory(settings.CategoryPredicate);
+
+        Assert.Equal(3, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(Settings.CacheSize),
+                nameof(GlobalSettings.Password),
+            ]);
+        Assert.Equal("Normal", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(Settings.UseCache),
+                nameof(Settings.Comment),
+            ]);
+        Assert.Equal("Asset", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.MemberName).ToArray(),
+            [
+                nameof(GlobalSettings.Id),
+            ]);
     }
 }

--- a/test/JSSoft.Commands.Tests/CommandMethodDescriptorCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandMethodDescriptorCollectionTest.cs
@@ -1,0 +1,150 @@
+// <copyright file="CommandMethodDescriptorCollectionTest.cs" company="JSSoft">
+//   Copyright (c) 2024 Jeesu Choi. All Rights Reserved.
+//   Licensed under the MIT License. See LICENSE.md in the project root for license information.
+// </copyright>
+
+using System.ComponentModel;
+
+namespace JSSoft.Commands.Tests;
+
+public class CommandMethodDescriptorCollectionTest
+{
+    internal static class StaticCommand
+    {
+        [CommandMethod]
+        [Category("Asset")]
+        public static void List()
+        {
+        }
+
+        [CommandMethod]
+        public static void Restore()
+        {
+        }
+
+        [CommandMethod]
+        public static void Revert()
+        {
+        }
+    }
+
+    [CommandStaticMethod(typeof(StaticCommand))]
+    internal sealed class Commands
+    {
+        [CommandMethod]
+        [Category("Hidden")]
+        public void Initialize()
+        {
+        }
+
+        [CommandMethod]
+        public void Add(params string[] paths)
+        {
+        }
+
+        [CommandMethod]
+        [Category("Normal")]
+        public void Update(string path = "")
+        {
+        }
+
+        [CommandMethod]
+        public void Delete(params string[] paths)
+        {
+        }
+
+        [CommandMethod]
+        [Category("Normal")]
+        public void Commit(string path = "")
+        {
+        }
+    }
+
+    [Fact]
+    public void Methods_Order_Test()
+    {
+        var methodDescriptors = CommandDescriptor.GetMethodDescriptors(typeof(Commands));
+        var index = 0;
+        Assert.Equal(8, methodDescriptors.Count);
+        Assert.Equal(nameof(Commands.Initialize), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(Commands.Add), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(Commands.Update), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(Commands.Delete), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(Commands.Commit), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(StaticCommand.List), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(StaticCommand.Restore), methodDescriptors[index++].MethodName);
+        Assert.Equal(nameof(StaticCommand.Revert), methodDescriptors[index++].MethodName);
+        Assert.Equal(8, index);
+    }
+
+    [Fact]
+    public void Method_GroupByCategory_Test()
+    {
+        var methodDescriptors = CommandDescriptor.GetMethodDescriptors(typeof(Commands));
+        var groups = methodDescriptors.GroupByCategory();
+
+        Assert.Equal(4, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(Commands.Add),
+                nameof(Commands.Delete),
+                nameof(StaticCommand.Restore),
+                nameof(StaticCommand.Revert),
+            ]);
+        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(Commands.Initialize),
+            ]);
+        Assert.Equal("Normal", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(Commands.Update),
+                nameof(Commands.Commit),
+            ]);
+        Assert.Equal("Asset", groups[3].Key);
+        Assert.Equal(
+            groups[3].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(StaticCommand.List),
+            ]);
+    }
+
+    [Fact]
+    public void Method_GroupByCategory_WithoutHidden_Test()
+    {
+        var settings = new CommandSettings();
+        var methodDescriptors = CommandDescriptor.GetMethodDescriptors(typeof(Commands));
+        var groups = methodDescriptors.GroupByCategory(settings.CategoryPredicate);
+
+        Assert.Equal(3, groups.Length);
+
+        Assert.Equal(string.Empty, groups[0].Key);
+        Assert.Equal(
+            groups[0].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(Commands.Add),
+                nameof(Commands.Delete),
+                nameof(StaticCommand.Restore),
+                nameof(StaticCommand.Revert),
+            ]);
+        Assert.Equal("Normal", groups[1].Key);
+        Assert.Equal(
+            groups[1].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(Commands.Update),
+                nameof(Commands.Commit),
+            ]);
+        Assert.Equal("Asset", groups[2].Key);
+        Assert.Equal(
+            groups[2].Select(item => item.MethodName).ToArray(),
+            [
+                nameof(StaticCommand.List),
+            ]);
+    }
+}

--- a/test/JSSoft.Commands.Tests/CommandMethodDescriptorTests/Parameter_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandMethodDescriptorTests/Parameter_Test.cs
@@ -26,8 +26,8 @@ public class Parameter_Test
         var index = 0;
         Assert.Equal(nameof(CustomParameter.String), methodDescriptor.Members[index++].MemberName);
         Assert.Equal(nameof(CustomParameter.Integer), methodDescriptor.Members[index++].MemberName);
-        Assert.Equal(nameof(CustomParameter.Name), methodDescriptor.Members[index++].MemberName);
         Assert.Equal(nameof(CustomParameter.Boolean), methodDescriptor.Members[index++].MemberName);
+        Assert.Equal(nameof(CustomParameter.Name), methodDescriptor.Members[index++].MemberName);
         Assert.Equal(4, index);
     }
 


### PR DESCRIPTION
### Bugfixes

* Fixed an issue where the options and command were not displayed in the order defined in the code.
* The options are especially displayed in the following order.
  * `Required` properties defined explicitly
  * `Required` properties with a default value
  * `Required` properties
  * `Variables` properties
  * `General` or `Switch` properties
