### PR TITLE
Improve help message output

### DIFF
--- a/example/Directory.Build.props
+++ b/example/Directory.Build.props
@@ -28,6 +28,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <DebugType Condition="'$(_IsPublishing)'=='true'">none</DebugType>
+    <DefineConstants>JSSOFT_COMMANDS</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
+  </ItemGroup>
 
 </Project>

--- a/example/GlobalUsings.cs
+++ b/example/GlobalUsings.cs
@@ -3,9 +3,4 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
-global using System;
-global using System.Collections.Generic;
-global using System.Linq;
-global using JSSoft.Terminals.Hosting;
-
-global using Xunit;
+global using JSSoft.Commands;

--- a/example/JSSoft.Commands.AppUI/JSSoft.Commands.AppUI.csproj
+++ b/example/JSSoft.Commands.AppUI/JSSoft.Commands.AppUI.csproj
@@ -25,7 +25,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <DefineConstants>JSSOFT_COMMANDS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,8 +44,9 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\**\*.cs" />
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\JSSoft.Commands.Shared.props" />
 
 </Project>

--- a/example/JSSoft.Commands.Invoke/GlobalSettings.cs
+++ b/example/JSSoft.Commands.Invoke/GlobalSettings.cs
@@ -9,7 +9,7 @@ namespace JSSoft.Commands.Invoke;
 internal static class GlobalSettings
 {
     [CommandProperty]
-    public static string ID { get; set; } = string.Empty;
+    public static string Id { get; set; } = string.Empty;
 
     [CommandProperty]
     public static string Password { get; set; } = string.Empty;

--- a/example/JSSoft.Commands.Invoke/JSSoft.Commands.Invoke.csproj
+++ b/example/JSSoft.Commands.Invoke/JSSoft.Commands.Invoke.csproj
@@ -22,7 +22,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>invoke</AssemblyName>
-    <DefineConstants>JSSOFT_COMMANDS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/example/JSSoft.Commands.Invoke/Program.cs
+++ b/example/JSSoft.Commands.Invoke/Program.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using JSSoft.Commands;
 using JSSoft.Commands.Invoke;
 
 try

--- a/example/JSSoft.Commands.Parse/GlobalSettings.cs
+++ b/example/JSSoft.Commands.Parse/GlobalSettings.cs
@@ -9,7 +9,7 @@ namespace JSSoft.Commands.Parse;
 internal static class GlobalSettings
 {
     [CommandProperty]
-    public static string ID { get; set; } = string.Empty;
+    public static string Id { get; set; } = string.Empty;
 
     [CommandProperty]
     public static string Password { get; set; } = string.Empty;

--- a/example/JSSoft.Commands.Parse/JSSoft.Commands.Parse.csproj
+++ b/example/JSSoft.Commands.Parse/JSSoft.Commands.Parse.csproj
@@ -22,11 +22,13 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>parse</AssemblyName>
-    <DefineConstants>JSSOFT_COMMANDS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\JSSoft.Commands\JSSoft.Commands.csproj" />
   </ItemGroup>
 

--- a/example/JSSoft.Commands.Parse/Program.cs
+++ b/example/JSSoft.Commands.Parse/Program.cs
@@ -20,7 +20,7 @@ try
     sb.AppendLine($"{nameof(settings.Port)}: {settings.Port}");
     sb.AppendLine($"{nameof(settings.UseCache)}: {settings.UseCache}");
     sb.AppendLine($"{nameof(settings.CacheSize)}: {settings.CacheSize}");
-    sb.AppendLine($"{nameof(GlobalSettings.ID)}: {GlobalSettings.ID}");
+    sb.AppendLine($"{nameof(GlobalSettings.Id)}: {GlobalSettings.Id}");
     sb.AppendLine($"{nameof(GlobalSettings.Password)}: {GlobalSettings.Password}");
     sb.AppendLine($"{nameof(settings.Libraries)}:");
     foreach (var item in settings.Libraries)

--- a/example/JSSoft.Commands.Parse/Program.cs
+++ b/example/JSSoft.Commands.Parse/Program.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Text;
-using JSSoft.Commands;
 using JSSoft.Commands.Parse;
 
 try

--- a/example/JSSoft.Commands.Parse/Settings.cs
+++ b/example/JSSoft.Commands.Parse/Settings.cs
@@ -37,6 +37,6 @@ internal sealed class Settings
     public string[] Libraries { get; set; } = [];
 
     [CommandProperty]
-    [Category("Hidden")]
+    [Category]
     public string Comment { get; set; } = string.Empty;
 }

--- a/example/JSSoft.Commands.Repl/JSSoft.Commands.Repl.csproj
+++ b/example/JSSoft.Commands.Repl/JSSoft.Commands.Repl.csproj
@@ -22,7 +22,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>repl</AssemblyName>
-    <DefineConstants>$(DefineConstants);JSSOFT_COMMANDS;JSSOFT_COMMANDS_REPL</DefineConstants>
+    <DefineConstants>$(DefineConstants);JSSOFT_COMMANDS_REPL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,8 +34,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     <ProjectReference Include="..\..\src\JSSoft.Terminals\JSSoft.Terminals.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\**\*.cs" />
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\JSSoft.Commands.Shared.props" />
 
 </Project>

--- a/example/JSSoft.Commands.Sets/JSSoft.Commands.Sets.csproj
+++ b/example/JSSoft.Commands.Sets/JSSoft.Commands.Sets.csproj
@@ -22,7 +22,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>sets</AssemblyName>
-    <DefineConstants>JSSOFT_COMMANDS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,9 +32,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     <ProjectReference Include="..\..\src\JSSoft.Commands\JSSoft.Commands.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\**\*.cs" />
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\**\*.resx" />
+  <Import Project="$(MSBuildThisFileDirectory)..\JSSoft.Commands.Shared\JSSoft.Commands.Shared.props" />
 
-  </ItemGroup>
 </Project>

--- a/example/JSSoft.Commands.Sets/Program.cs
+++ b/example/JSSoft.Commands.Sets/Program.cs
@@ -3,7 +3,6 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
-using System;
 using JSSoft.Commands.Repl;
 
 var application = new Application();

--- a/example/JSSoft.Commands.Shared/Commands/GlobalSettings.cs
+++ b/example/JSSoft.Commands.Shared/Commands/GlobalSettings.cs
@@ -9,7 +9,7 @@ namespace JSSoft.Commands.Applications.Commands;
 internal static class GlobalSettings
 {
     [CommandProperty]
-    public static string ID { get; set; } = string.Empty;
+    public static string Id { get; set; } = string.Empty;
 
     [CommandProperty]
     public static string Password { get; set; } = string.Empty;

--- a/example/JSSoft.Commands.Shared/Commands/TestCommand.cs
+++ b/example/JSSoft.Commands.Shared/Commands/TestCommand.cs
@@ -20,7 +20,7 @@ namespace JSSoft.Commands.Applications.Commands;
 [Export(typeof(ICommand))]
 [CommandSummary("Test Command")]
 [method: ImportingConstructor]
-[Category("Hidden")]
+[Category]
 internal sealed class TestCommand(IApplication application) : CommandMethodBase(["t"]), IDisposable
 {
     private readonly IApplication _application = application;

--- a/example/JSSoft.Commands.Shared/JSSoft.Commands.Shared.props
+++ b/example/JSSoft.Commands.Shared/JSSoft.Commands.Shared.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)**\*.cs" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)**\*.resx" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)**\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
@@ -32,6 +32,8 @@ public class CommandInvocationUsagePrinter(
             PrintExample(commandWriter, commandUsage.Example);
             PrintCommands(commandWriter, methodDescriptors, Settings.CategoryPredicate);
         }
+
+        PrintHelpMessage(commandWriter, executionName);
     }
 
     public virtual void Print(TextWriter writer, CommandMethodDescriptor methodDescriptor)

--- a/src/JSSoft.Commands/CommandParameterDescriptor.cs
+++ b/src/JSSoft.Commands/CommandParameterDescriptor.cs
@@ -3,7 +3,6 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
-using System.ComponentModel;
 using JSSoft.Commands.Exceptions;
 using static JSSoft.Commands.AttributeUtility;
 

--- a/src/JSSoft.Commands/CommandSettings.cs
+++ b/src/JSSoft.Commands/CommandSettings.cs
@@ -6,6 +6,7 @@
 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable S3011
 
+using System.ComponentModel;
 using System.Diagnostics;
 using JSSoft.Commands.Extensions;
 using static JSSoft.Commands.CommandUtility;
@@ -20,7 +21,8 @@ public sealed record class CommandSettings
     public const char DefaultHelpShortName = 'h';
     public const string DefaultVersionName = "version";
     public const char DefaultVersionShortName = 'v';
-    public static readonly Predicate<string> DefaultCategoryPredicate = s => s != "Hidden";
+    public static readonly Predicate<string> DefaultCategoryPredicate
+        = s => s != CategoryAttribute.Default.Category;
 
     private int _labelWith = DefaultLabelWidth;
     private int _indentSpaces = DefaultIndentSpaces;

--- a/src/JSSoft.Commands/CommandUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinter.cs
@@ -66,6 +66,11 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
                 PrintOptions(commandWriter, memberDescriptors, Settings.CategoryPredicate);
             }
         }
+
+        if (command.AllowsSubCommands is true)
+        {
+            PrintHelpMessage(commandWriter, executionName);
+        }
     }
 
     protected static void PrintCommands(

--- a/src/JSSoft.Commands/CommandUsagePrinterBase.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinterBase.cs
@@ -383,4 +383,11 @@ public abstract class CommandUsagePrinterBase(CommandSettings settings)
             commandWriter.WriteLinesIf(separatorCount, condition: isLast is false);
         }
     }
+
+    protected static void PrintHelpMessage(CommandTextWriter commandWriter, string executionName)
+    {
+        commandWriter.WriteLine($"Run '{executionName} <command> --help' to get help for " +
+                                $"a specific command.");
+        commandWriter.WriteLine("Use the --detail option for a more detailed description.");
+    }
 }

--- a/src/JSSoft.Commands/ResourceUsageAttribute.cs
+++ b/src/JSSoft.Commands/ResourceUsageAttribute.cs
@@ -10,7 +10,7 @@ using static JSSoft.Commands.ResourceManagerUtility;
 namespace JSSoft.Commands;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ResourceUsageAttribute : CommandUsageAttribute
+public sealed class ResourceUsageAttribute : CommandUsageAttribute
 {
     public ResourceUsageAttribute()
     {

--- a/src/JSSoft.Commands/VersionCommandBase.cs
+++ b/src/JSSoft.Commands/VersionCommandBase.cs
@@ -3,12 +3,14 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
+using System.ComponentModel;
 using System.Text;
 using JSSoft.Commands.Extensions;
 
 namespace JSSoft.Commands;
 
 [ResourceUsage]
+[Category]
 public abstract class VersionCommandBase : CommandBase
 {
     protected VersionCommandBase()

--- a/src/JSSoft.Terminals/Hosting/Ansi/AsciiCodeContext.cs
+++ b/src/JSSoft.Terminals/Hosting/Ansi/AsciiCodeContext.cs
@@ -3,8 +3,6 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
-using JSSoft.Terminals.Extensions;
-
 namespace JSSoft.Terminals.Hosting.Ansi;
 
 internal sealed class AsciiCodeContext(TerminalLineCollection lines, string text, ITerminal terminal)

--- a/test/JSSoft.Commands.Tests/CommandCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandCollectionTest.cs
@@ -9,7 +9,7 @@ namespace JSSoft.Commands.Tests;
 
 public class CommandCollectionTest
 {
-    [Category("Hidden")]
+    [Category]
     private sealed class HiddenCommand : CommandBase
     {
         protected override void OnExecute()
@@ -85,7 +85,7 @@ public class CommandCollectionTest
             [
                 typeof(DeleteCommand),
             ]);
-        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(CategoryAttribute.Default.Category, groups[1].Key);
         Assert.Equal(
             groups[1].Select(item => item.GetType()).ToArray(),
             [

--- a/test/JSSoft.Commands.Tests/CommandContextTests/CommandAsICustomCommandDescriptor.cs
+++ b/test/JSSoft.Commands.Tests/CommandContextTests/CommandAsICustomCommandDescriptor.cs
@@ -3,10 +3,6 @@
 //   Licensed under the MIT License. See LICENSE.md in the project root for license information.
 // </copyright>
 
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace JSSoft.Commands.Tests.CommandContextTests;
 
 public class CommandAsICustomCommandDescriptor

--- a/test/JSSoft.Commands.Tests/CommandInvokerTests/Validation_Test.cs
+++ b/test/JSSoft.Commands.Tests/CommandInvokerTests/Validation_Test.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System.ComponentModel.DataAnnotations;
-using NuGet.Frameworks;
 
 namespace JSSoft.Commands.Tests.CommandInvokerTests;
 

--- a/test/JSSoft.Commands.Tests/CommandMemberDescriptorCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandMemberDescriptorCollectionTest.cs
@@ -38,7 +38,7 @@ public class CommandMemberDescriptorCollectionTest
         public string WorkingPath { get; set; } = string.Empty;
 
         [CommandProperty('p', useName: true, InitValue = "10001")]
-        [Category("Hidden")]
+        [Category]
         public int Port { get; set; }
 
         [CommandPropertySwitch]
@@ -92,7 +92,7 @@ public class CommandMemberDescriptorCollectionTest
                 nameof(Settings.CacheSize),
                 nameof(GlobalSettings.Password),
             ]);
-        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(CategoryAttribute.Default.Category, groups[1].Key);
         Assert.Equal(
             groups[1].Select(item => item.MemberName).ToArray(),
             [

--- a/test/JSSoft.Commands.Tests/CommandMethodDescriptorCollectionTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandMethodDescriptorCollectionTest.cs
@@ -32,7 +32,7 @@ public class CommandMethodDescriptorCollectionTest
     internal sealed class Commands
     {
         [CommandMethod]
-        [Category("Hidden")]
+        [Category]
         public void Initialize()
         {
         }
@@ -94,7 +94,7 @@ public class CommandMethodDescriptorCollectionTest
                 nameof(StaticCommand.Restore),
                 nameof(StaticCommand.Revert),
             ]);
-        Assert.Equal("Hidden", groups[1].Key);
+        Assert.Equal(CategoryAttribute.Default.Category, groups[1].Key);
         Assert.Equal(
             groups[1].Select(item => item.MethodName).ToArray(),
             [

--- a/test/JSSoft.Tests.Shared/RandomUtility.Dictionary.cs
+++ b/test/JSSoft.Tests.Shared/RandomUtility.Dictionary.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System.Collections.Immutable;
-using System.Security;
 
 #if JSSOFT_COMMANDS
 namespace JSSoft.Commands.Tests;


### PR DESCRIPTION
### Improvements

* Now displays the '--help'-related message at the end of the help output as shown below.

```plain
Run '{executionName} <command> --help' to get help for a specific command.
Use the --detail option for a more detailed description.
```