### PR TITLE
Integrate usage-related properties of ICommand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be Released.
 * Fixed an issue with the display order of options and commands in Help.  
   [[#37]]
 * Removed commands sorting code in `CommandContextBase`.  [[#38]]
+* Integrated usage-related properties(`Summary`, `Description`, `Example`) into 
+  the `CommandUsage` property.  [[#40]]
 
 [#13]: https://github.com/s2quake/commands/pull/13
 [#17]: https://github.com/s2quake/commands/pull/17
@@ -43,6 +45,7 @@ To be Released.
 [#34]: https://github.com/s2quake/commands/pull/34
 [#37]: https://github.com/s2quake/commands/pull/37
 [#38]: https://github.com/s2quake/commands/pull/38
+[#40]: https://github.com/s2quake/commands/pull/40
 
 
 6.0.1

--- a/src/JSSoft.Commands/CommandAsyncBase.cs
+++ b/src/JSSoft.Commands/CommandAsyncBase.cs
@@ -89,11 +89,7 @@ public abstract class CommandAsyncBase : ICommand, IAsyncExecutable
         set => _context = value;
     }
 
-    string ICommand.Summary => _usage.Summary;
-
-    string ICommand.Description => _usage.Description;
-
-    string ICommand.Example => _usage.Example;
+    CommandUsage ICommand.Usage => _usage;
 
     string ICommand.Category => AttributeUtility.GetCategory(GetType());
 

--- a/src/JSSoft.Commands/CommandBase.cs
+++ b/src/JSSoft.Commands/CommandBase.cs
@@ -86,11 +86,7 @@ public abstract class CommandBase : ICommand, IExecutable
         set => _context = value;
     }
 
-    string ICommand.Summary => _usage.Summary;
-
-    string ICommand.Description => _usage.Description;
-
-    string ICommand.Example => _usage.Example;
+    CommandUsage ICommand.Usage => _usage;
 
     string ICommand.Category => AttributeUtility.GetCategory(GetType());
 

--- a/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandInvocationUsagePrinter.cs
@@ -86,7 +86,7 @@ public class CommandInvocationUsagePrinter(
     {
         var groupName = StringByName[TextSummary];
         using var groupScope = commandWriter.Group(groupName);
-        var summary = methodDescriptor.UsageDescriptor.Summary;
+        var summary = methodDescriptor.Usage.Summary;
         var width = commandWriter.Width - commandWriter.TotalIndentSpaces;
         var lines = CommandTextWriter.Wrap(summary, width);
         commandWriter.WriteLine(lines);
@@ -97,7 +97,7 @@ public class CommandInvocationUsagePrinter(
     {
         var groupName = StringByName[TextDescription];
         using var groupScope = commandWriter.Group(groupName);
-        var description = methodDescriptor.UsageDescriptor.Description;
+        var description = methodDescriptor.Usage.Description;
         var width = commandWriter.Width - commandWriter.TotalIndentSpaces;
         var lines = CommandTextWriter.Wrap(description, width);
         commandWriter.WriteLine(lines);
@@ -108,7 +108,7 @@ public class CommandInvocationUsagePrinter(
     {
         var groupName = StringByName[TextExample];
         using var groupScope = commandWriter.Group(groupName);
-        var example = methodDescriptor.UsageDescriptor.Example;
+        var example = methodDescriptor.Usage.Example;
         commandWriter.WriteLine(example);
     }
 
@@ -135,7 +135,7 @@ public class CommandInvocationUsagePrinter(
             foreach (var item in methodDescriptors)
             {
                 var label = GetMethodString(item);
-                var summary = item.UsageDescriptor.Summary;
+                var summary = item.Usage.Summary;
                 commandWriter.WriteLine(label: label, summary: summary);
             }
         }
@@ -162,7 +162,7 @@ public class CommandInvocationUsagePrinter(
             foreach (var item in methodDescriptors)
             {
                 var label = GetMethodString(item);
-                var description = item.UsageDescriptor.Description;
+                var description = item.Usage.Description;
                 var isLast = item == methodDescriptors.Last();
                 commandWriter.WriteLine(label);
                 commandWriter.WriteLineIndent(description, commandWriter.Indent + 1);

--- a/src/JSSoft.Commands/CommandMethodBase.cs
+++ b/src/JSSoft.Commands/CommandMethodBase.cs
@@ -87,11 +87,7 @@ public abstract class CommandMethodBase : ICommand
 
     CommandCollection ICommand.Commands => _commands;
 
-    string ICommand.Summary => _usage.Summary;
-
-    string ICommand.Description => _usage.Description;
-
-    string ICommand.Example => _usage.Example;
+    CommandUsage ICommand.Usage => _usage;
 
     string ICommand.Category => AttributeUtility.GetCategory(GetType());
 

--- a/src/JSSoft.Commands/CommandMethodDescriptor.cs
+++ b/src/JSSoft.Commands/CommandMethodDescriptor.cs
@@ -27,7 +27,7 @@ public abstract class CommandMethodDescriptor(MethodInfo methodInfo)
 
     public MethodInfo MethodInfo { get; } = methodInfo;
 
-    public CommandUsage UsageDescriptor { get; } = CommandDescriptor.GetUsage(methodInfo);
+    public CommandUsage Usage { get; } = CommandDescriptor.GetUsage(methodInfo);
 
     internal bool CanExecute(object instance) => OnCanExecute(instance);
 

--- a/src/JSSoft.Commands/CommandNode.cs
+++ b/src/JSSoft.Commands/CommandNode.cs
@@ -18,13 +18,9 @@ internal sealed class CommandNode(CommandContextBase commandContext) : ICommand
 
     public bool AllowsSubCommands => true;
 
-    public string Summary { get; } = string.Empty;
-
-    public string Description { get; } = string.Empty;
-
-    public string Example { get; } = string.Empty;
-
     public string Category { get; } = string.Empty;
+
+    public CommandUsage Usage { get; } = CommandDescriptor.GetUsage(commandContext.GetType());
 
     public ICommand? Parent { get; }
 

--- a/src/JSSoft.Commands/CommandUsagePrinter.cs
+++ b/src/JSSoft.Commands/CommandUsagePrinter.cs
@@ -19,7 +19,7 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
         var executionName = command.GetExecutionName();
         if (IsDetail is true)
         {
-            PrintSummary(commandWriter, command.Summary);
+            PrintSummary(commandWriter, command.Usage.Summary);
             if (command.AllowsSubCommands is true)
             {
                 PrintUsage(commandWriter, executionName);
@@ -29,8 +29,8 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
                 PrintUsage(commandWriter, executionName, memberDescriptors);
             }
 
-            PrintDescription(commandWriter, command.Description);
-            PrintExample(commandWriter, command.Example);
+            PrintDescription(commandWriter, command.Usage.Description);
+            PrintExample(commandWriter, command.Usage.Example);
             if (command.AllowsSubCommands is true)
             {
                 PrintCommandsInDetail(commandWriter, command.Commands);
@@ -44,7 +44,7 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
         }
         else
         {
-            PrintSummary(commandWriter, command.Summary);
+            PrintSummary(commandWriter, command.Usage.Summary);
             if (command.AllowsSubCommands is true)
             {
                 PrintUsage(commandWriter, executionName);
@@ -54,7 +54,7 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
                 PrintUsage(commandWriter, executionName, memberDescriptors);
             }
 
-            PrintExample(commandWriter, command.Example);
+            PrintExample(commandWriter, command.Usage.Example);
             if (command.AllowsSubCommands is true)
             {
                 PrintCommands(commandWriter, command.Commands, Settings.CategoryPredicate);
@@ -131,7 +131,7 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
         foreach (var command in commands)
         {
             var label = GetCommandString(command);
-            var summary = command.Summary;
+            var summary = command.Usage.Summary;
             commandWriter.WriteLine(label: label, summary: summary);
         }
     }
@@ -143,7 +143,7 @@ public class CommandUsagePrinter(ICommand command, CommandSettings settings)
         foreach (var command in commands)
         {
             var label = GetCommandString(command);
-            var description = command.Description;
+            var description = command.Usage.Description;
             var isLast = command == commands.Last();
             commandWriter.WriteLine(label);
             commandWriter.WriteLineIndent(description, commandWriter.Indent + 1);

--- a/src/JSSoft.Commands/ICommand.cs
+++ b/src/JSSoft.Commands/ICommand.cs
@@ -15,13 +15,9 @@ public interface ICommand
 
     bool AllowsSubCommands { get; }
 
-    string Summary { get; }
-
-    string Description { get; }
-
-    string Example { get; }
-
     string Category { get; }
+
+    CommandUsage Usage { get; }
 
     ICommand? Parent { get; set; }
 

--- a/src/JSSoft.Commands/SubCommand.cs
+++ b/src/JSSoft.Commands/SubCommand.cs
@@ -26,11 +26,7 @@ internal sealed class SubCommand(CommandMethodBase method, CommandMethodDescript
 
     bool ICommand.AllowsSubCommands => false;
 
-    string ICommand.Summary => _methodDescriptor.UsageDescriptor.Summary;
-
-    string ICommand.Description => _methodDescriptor.UsageDescriptor.Description;
-
-    string ICommand.Example => _methodDescriptor.UsageDescriptor.Example;
+    CommandUsage ICommand.Usage => _methodDescriptor.Usage;
 
     string ICommand.Category => _methodDescriptor.Category;
 

--- a/src/JSSoft.Commands/SubCommandAsync.cs
+++ b/src/JSSoft.Commands/SubCommandAsync.cs
@@ -11,9 +11,7 @@ namespace JSSoft.Commands;
 
 internal sealed class SubCommandAsync(
     CommandMethodBase method, CommandMethodDescriptor methodDescriptor)
-    : CommandMethodInstance(methodDescriptor),
-    ICommand,
-    IAsyncExecutable
+    : CommandMethodInstance(methodDescriptor), ICommand, IAsyncExecutable
 {
     private readonly CommandMethodDescriptor _methodDescriptor = methodDescriptor;
 
@@ -29,11 +27,7 @@ internal sealed class SubCommandAsync(
 
     bool ICommand.AllowsSubCommands => false;
 
-    string ICommand.Summary => _methodDescriptor.UsageDescriptor.Summary;
-
-    string ICommand.Description => _methodDescriptor.UsageDescriptor.Description;
-
-    string ICommand.Example => _methodDescriptor.UsageDescriptor.Example;
+    CommandUsage ICommand.Usage => _methodDescriptor.Usage;
 
     string ICommand.Category => _methodDescriptor.Category;
 

--- a/test/JSSoft.Commands.Tests/CommandContextTests/CustomCommandTest.cs
+++ b/test/JSSoft.Commands.Tests/CommandContextTests/CustomCommandTest.cs
@@ -28,11 +28,12 @@ public class CustomCommandTest
 
         public bool AllowsSubCommands => false;
 
-        public string Summary => nameof(Summary);
-
-        public string Description => nameof(Description);
-
-        public string Example => nameof(Example);
+        public CommandUsage Usage { get; } = new()
+        {
+            Summary = nameof(CommandUsage.Summary),
+            Description = nameof(CommandUsage.Description),
+            Example = nameof(CommandUsage.Example),
+        };
 
         public string Category => string.Empty;
 
@@ -67,11 +68,12 @@ public class CustomCommandTest
 
         public bool AllowsSubCommands => false;
 
-        public string Summary => nameof(Summary);
-
-        public string Description => nameof(Description);
-
-        public string Example => nameof(Example);
+        public CommandUsage Usage { get; } = new()
+        {
+            Summary = nameof(CommandUsage.Summary),
+            Description = nameof(CommandUsage.Description),
+            Example = nameof(CommandUsage.Example),
+        };
 
         public string Category => string.Empty;
 
@@ -113,11 +115,12 @@ public class CustomCommandTest
 
         public bool AllowsSubCommands => false;
 
-        public string Summary => nameof(Summary);
-
-        public string Description => nameof(Description);
-
-        public string Example => nameof(Example);
+        public CommandUsage Usage { get; } = new()
+        {
+            Summary = nameof(CommandUsage.Summary),
+            Description = nameof(CommandUsage.Description),
+            Example = nameof(CommandUsage.Example),
+        };
 
         public string Category => string.Empty;
 


### PR DESCRIPTION
### Refactoring

* Removed the following properties from `ICommand`:
  * Summary
  * Description
  * Example
* Added a `Usage` property of type `CommandUsage`
